### PR TITLE
Use resolutions to update ansi-html to 0.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,6 @@
     "configPath": "tests/dummy/config"
   },
   "resolutions": {
-  "ansi-html": "0.0.8"
-}
+    "ansi-html": "0.0.8"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -87,5 +87,8 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"
-  }
+  },
+  "resolutions": {
+  "ansi-html": "0.0.8"
+}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2102,10 +2102,10 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.2:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-html@^0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
-  integrity sha512-JoAxEa1DfP9m2xfB/y2r/aKcwXNlltr4+0QSBC4TrLfcxyvepX2Pv0t/xpgGV5bGsDzCYV8SzjWgyCW0T9yYbA==
+ansi-html@0.0.8, ansi-html@^0.0.7:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.8.tgz#e969db193b12bcdfa6727b29ffd8882dc13cc501"
+  integrity sha512-QROYz1I1Kj+8bTYgx0IlMBpRSCIU+7GjbE0oH+KF7QKc+qSF8YAlIutN59Db17tXN70Ono9upT9Ht0iG93W7ug==
 
 ansi-regex@^2.0.0:
   version "2.1.1"


### PR DESCRIPTION
Closes https://github.com/htdc/hotdoc-ember-dashboard/issues/7399

Should resolve this dependabot: https://github.com/htdc/ember-cli-deploy-front-end-builds/security/dependabot/103