### PR TITLE
[dev] Update passwd-user to help resolve bookings vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ember-cli-babel": "^8.2.0",
     "ember-cli-htmlbars": "^6.3.0",
     "node-fetch": "^2",
-    "passwd-user": "^3.0.0"
+    "passwd-user": "^4.0.0"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.24.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7566,12 +7566,12 @@ parseurl@~1.3.3:
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
 
-passwd-user@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/passwd-user/-/passwd-user-3.0.0.tgz#cb164c7cec4636ecbdffeb6ba369bf109654b068"
-  integrity sha512-Iu90rROks+uDK00ppSewoZyqeCwjGR6W8PcY0Phl8YFWju/lRmIogQb98+vSb5RUeYkONL3IC4ZLBFg4FiE0Hg==
+passwd-user@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/passwd-user/-/passwd-user-4.0.0.tgz#426d2deef874fc036deb1dc2d21434b0d7b94c27"
+  integrity sha512-Y0hVgYTHsWRkOF/lG2ciRChuD1kiQCGbmg9hQuyxRrszz2B9779U8nUa90NVJ089UTCFIcvfQ6zgmbXj/YoIYg==
   dependencies:
-    execa "^1.0.0"
+    execa "^5.1.1"
 
 path-exists@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Bookings vulnerability that currently getting blocked on this upgrade: https://github.com/htdc/hotdoc-ember-bookings/security/dependabot/232

Note that its been upgraded previously here: https://github.com/htdc/ember-cli-deploy-front-end-builds/pull/2/commits/def8b35382b5521bd5895600eb97e3c0ea88508f