### PR TITLE
[security] Remove vulnerable passwd-user package

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
 'use strict';
 
 const BasePlugin = require('ember-cli-deploy-plugin');
-const passwdUser = require('passwd-user');
+const os = require('os');
 const FrontEndBuildsNotifier = require('./lib/front-end-builds-notifier');
 
 module.exports = {
   name: require('./package').name,
 
   createDeployPlugin(options) {
-    const homedir = passwdUser.sync(process.getuid()).homeDirectory;
+    const homedir = os.homedir();
     const DeployPlugin = BasePlugin.extend({
       name: options.name,
 

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "core-object": "^3.1.5",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-htmlbars": "^6.3.0",
-    "node-fetch": "^2",
-    "passwd-user": "^4.0.0"
+    "node-fetch": "^2"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.24.7",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ember-cli-babel": "^8.2.0",
     "ember-cli-htmlbars": "^6.3.0",
     "node-fetch": "^2",
-    "passwd-user": "^3.0.0"
+    "passwd-user": "^4.0.0"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.24.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7566,12 +7566,12 @@ parseurl@~1.3.3:
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
 
-passwd-user@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/passwd-user/-/passwd-user-3.0.0.tgz#cb164c7cec4636ecbdffeb6ba369bf109654b068"
-  integrity sha512-Iu90rROks+uDK00ppSewoZyqeCwjGR6W8PcY0Phl8YFWju/lRmIogQb98+vSb5RUeYkONL3IC4ZLBFg4FiE0Hg==
+passwd-user@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/passwd-user/-/passwd-user-4.0.0.tgz#426d2deef874fc036deb1dc2d21434b0d7b94c27"
+  integrity sha512-Y0hVgYTHsWRkOF/lG2ciRChuD1kiQCGbmg9hQuyxRrszz2B9779U8nUa90NVJ089UTCFIcvfQ6zgmbXj/YoIYg==
   dependencies:
-    execa "^1.0.0"
+    execa "^5.1.1"
 
 path-exists@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7566,13 +7566,6 @@ parseurl@~1.3.3:
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
 
-passwd-user@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/passwd-user/-/passwd-user-4.0.0.tgz#426d2deef874fc036deb1dc2d21434b0d7b94c27"
-  integrity sha512-Y0hVgYTHsWRkOF/lG2ciRChuD1kiQCGbmg9hQuyxRrszz2B9779U8nUa90NVJ089UTCFIcvfQ6zgmbXj/YoIYg==
-  dependencies:
-    execa "^5.1.1"
-
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"


### PR DESCRIPTION
Instead of bumping ([which failed here](https://github.com/htdc/ember-cli-deploy-front-end-builds/pull/25#issuecomment-2537384551)) - Im going to try removing and replacing with the built-in solution (os module) to get the home directory (which is the purpose of including this package in the first place)